### PR TITLE
Preview button playback speed dependant

### DIFF
--- a/src/components/SponsorTimeEditComponent.tsx
+++ b/src/components/SponsorTimeEditComponent.tsx
@@ -380,7 +380,7 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
 
         const skipTime = sponsorTimes[index].segment[0];
 
-        this.props.contentContainer().previewTime(skipTime - 2);
+        this.props.contentContainer().previewTime(skipTime - (2*this.props.contentContainer().v.playbackRate));
     }
 
     inspectTime(): void {


### PR DESCRIPTION
Pressing "Preview" will now jump 2 seconds in front of the segment start time, depending on the playback speed.

- [ ] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
